### PR TITLE
fixed https://github.com/typingArtist/linux_media/issues/1

### DIFF
--- a/drivers/media/pci/saa716x/saa716x_adap.c
+++ b/drivers/media/pci/saa716x/saa716x_adap.c
@@ -99,7 +99,7 @@ int saa716x_dvb_init(struct saa716x_dev *saa716x)
 		dprintk(SAA716x_DEBUG, 1, "dvb_register_adapter");
 		if (dvb_register_adapter(&saa716x_adap->dvb_adapter,
 					 "SAA716x dvb adapter",
-					 THIS_MODULE,
+					 saa716x->module,
 					 &saa716x->pdev->dev,
 					 adapter_nr) < 0) {
 

--- a/drivers/media/pci/saa716x/saa716x_budget.c
+++ b/drivers/media/pci/saa716x/saa716x_budget.c
@@ -73,6 +73,7 @@ static int saa716x_budget_pci_probe(struct pci_dev *pdev, const struct pci_devic
 	saa716x->verbose	= verbose;
 	saa716x->int_type	= int_type;
 	saa716x->pdev		= pdev;
+	saa716x->module		= THIS_MODULE;
 	saa716x->config		= (struct saa716x_config *) pci_id->driver_data;
 
 	err = saa716x_pci_init(saa716x);

--- a/drivers/media/pci/saa716x/saa716x_ff_main.c
+++ b/drivers/media/pci/saa716x/saa716x_ff_main.c
@@ -986,6 +986,7 @@ static int saa716x_ff_pci_probe(struct pci_dev *pdev, const struct pci_device_id
 	saa716x->verbose	= verbose;
 	saa716x->int_type	= int_type;
 	saa716x->pdev		= pdev;
+	saa716x->module		= THIS_MODULE;
 	saa716x->config		= (struct saa716x_config *) pci_id->driver_data;
 
 	err = saa716x_pci_init(saa716x);

--- a/drivers/media/pci/saa716x/saa716x_hybrid.c
+++ b/drivers/media/pci/saa716x/saa716x_hybrid.c
@@ -63,6 +63,7 @@ static int saa716x_hybrid_pci_probe(struct pci_dev *pdev, const struct pci_devic
 	saa716x->verbose	= verbose;
 	saa716x->int_type	= int_type;
 	saa716x->pdev		= pdev;
+	saa716x->module		= THIS_MODULE;
 	saa716x->config		= (struct saa716x_config *) pci_id->driver_data;
 
 	err = saa716x_pci_init(saa716x);

--- a/drivers/media/pci/saa716x/saa716x_priv.h
+++ b/drivers/media/pci/saa716x/saa716x_priv.h
@@ -127,6 +127,7 @@ struct saa716x_adapter {
 struct saa716x_dev {
 	struct saa716x_config		*config;
 	struct pci_dev			*pdev;
+	struct module			*module;
 
 	int				num; /* device count */
 	int				verbose;


### PR DESCRIPTION
Without this patch applied, saa716x_core takes all reference counts and leaves the
specific modules like saa716x_budget without a use tick. This leads to the situation
that while the application is running, saa716x_budget still has a reference count of
zero and can be unloaded, which freezes the kernel immediately. It is necessary for
dvb_register_adapter to get a reference to the real adapter-specific module to avoid
this case.
