### PR TITLE
saa716x: Fix errors and improve saa716x_set_clk

### DIFF
--- a/drivers/media/pci/saa716x/saa716x_cgu.c
+++ b/drivers/media/pci/saa716x/saa716x_cgu.c
@@ -483,15 +483,15 @@ int saa716x_set_clk(struct saa716x_dev *saa716x,
 	add = M_tmp - N_tmp;
 	lsb = 4; /* run */
 
-	if (((10 * N) / M) < 5)
+	if (((10 * N) / M) <= 5)
 		lsb |= 1; /* stretch */
 
 	/* store new divider */
 	cgu->clk_curr_div[domain] = sub & 0xff;
 	cgu->clk_curr_div[domain] <<= 8;
-	cgu->clk_curr_div[domain] = add & 0xff;
+	cgu->clk_curr_div[domain] |= add & 0xff;
 	cgu->clk_curr_div[domain] <<= 3;
-	cgu->clk_curr_div[domain]  |= lsb;
+	cgu->clk_curr_div[domain] |= lsb;
 
 	dprintk(SAA716x_DEBUG, 1, "Domain <0x%02x> Frequency <%d> Set Freq <%d> N=%d M=%d Divider <0x%02x>",
 		domain,
@@ -508,10 +508,10 @@ int saa716x_set_clk(struct saa716x_dev *saa716x,
 
 	/* Reset disable */
 	for (i = 0; i < 1000; i++) {
-		msleep(10);
+		udelay(10);
 		reset = SAA716x_EPRD(CGU, cgu_clk[domain]);
 
-		if (cgu->clk_curr_div[domain == reset])
+		if (cgu->clk_curr_div[domain] == reset)
 			break;
 	}
 


### PR DESCRIPTION
- Use stretched clock also for 125 MHz as its active for default 125 MHz clocks.
- Fix not setting MSUB in clock divider.
- Sleep for 10 us instead of 10 ms.
- Fix typo in condition.

Signed-off-by: Andreas Regel andreas.regel@gmx.de

Credits: powARman
