### PR TITLE
saa716x: initialize si2168_config struct

### DIFF
--- a/drivers/media/pci/saa716x/saa716x_budget.c
+++ b/drivers/media/pci/saa716x/saa716x_budget.c
@@ -919,6 +919,7 @@ static int saa716x_tbs6281_frontend_attach(struct saa716x_adapter *adapter, int 
 	adapter->i2c_client_demod = client;
 
 	/* attach tuner */
+	memset(&si2157_config, 0, sizeof(si2157_config));
 	si2157_config.fe = adapter->fe;
 	memset(&info, 0, sizeof(struct i2c_board_info));
 	strlcpy(info.type, "si2157", I2C_NAME_SIZE);
@@ -1012,6 +1013,7 @@ static int saa716x_tbs6285_frontend_attach(struct saa716x_adapter *adapter, int 
 	adapter->i2c_client_demod = client;
 
 	/* attach tuner */
+	memset(&si2157_config, 0, sizeof(si2157_config));
 	si2157_config.fe = adapter->fe;
 	memset(&info, 0, sizeof(struct i2c_board_info));
 	strlcpy(info.type, "si2157", I2C_NAME_SIZE);


### PR DESCRIPTION
When new parameters are added for si2168 driver, the parameters have to be explicitly defined for each device if the
si2168_config struct is not initialized to all zeros.

Signed-off-by: Olli Salonen olli.salonen@iki.fi
Signed-off-by: Mauro Carvalho Chehab mchehab@osg.samsung.com

Credits: trsqr
