### PR TITLE
saa716x: Fix two compiler errors

### DIFF
--- a/drivers/media/pci/saa716x/saa716x_pci.c
+++ b/drivers/media/pci/saa716x/saa716x_pci.c
@@ -1,4 +1,6 @@
 #include <asm/io.h>
+#include <linux/spinlock_types.h>
+#include <asm/atomic.h>
 #include <asm/pgtable.h>
 #include <asm/page.h>
 #include <linux/kmod.h>


### PR DESCRIPTION
Hi Luis,
compiling the beloved saa716x driver into linux-4.2-rc1 results in two compiler errors, due to lacking includes.
This patch fixes that.
The errors are:

CC [M]  drivers/media/pci/saa716x/saa716x_pci.o
In file included from drivers/media/pci/saa716x/saa716x_pci.c:2:0:
./arch/x86/include/asm/pgtable.h:31:8: error: unknown type name ‘spinlock_t’
 extern spinlock_t pgd_lock;
        ^
In file included from ./arch/x86/include/asm/pgtable.h:425:0,
                 from drivers/media/pci/saa716x/saa716x_pci.c:2:
./arch/x86/include/asm/pgtable_64.h: In function ‘native_ptep_get_and_clear’:
./arch/x86/include/asm/pgtable_64.h:76:2: error: implicit declaration of function ‘xchg’ [-Werror=implicit-function-declaration]
  return native_make_pte(xchg(&xp->pte, 0));
  ^